### PR TITLE
Set build env vars securely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up repository and variables
         run: |
           git fetch --prune --unshallow --tags -f
-          echo "::set-env name=NWNSC_VERSION::`git describe --tags --dirty=-dirty --always`"
+          echo "NWNSC_VERSION=`git describe --tags --dirty=-dirty --always`" >> $GITHUB_ENV
         shell: bash
 
       # Install OS specific dependencies


### PR DESCRIPTION
The actions command `set-env` has been replaced. For details, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/