### PR TITLE
Support bison 3.6.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,11 @@ if (MSVC)
 	endforeach(flag_var)
 endif()
 
-if (BISON_VERSION VERSION_GREATER "3.0.0")
+if (BISON_VERSION VERSION_GREATER "3.6.0")
+   add_definitions(-DNWN_BISON_3_6=1)
+elseif (BISON_VERSION VERSION_GREATER "3.0.0")
    add_definitions(-DNWN_BISON_3=1)
-endif (BISON_VERSION VERSION_GREATER "3.0.0")
+endif (BISON_VERSION VERSION_GREATER "3.6.0")
 
 add_subdirectory(_NwnBaseLib)
 add_subdirectory(_NwnDataLib)

--- a/_NscLib/NscCompat.h
+++ b/_NscLib/NscCompat.h
@@ -5,13 +5,22 @@
    the NWN_BISON_3 macro is defined by the CMakeLists.txt
    based on the version of bison found
 */
-#     define YYEMPTY		(-2)
-#ifdef NWN_BISON_3
+#ifdef NWN_BISON_3_6
+#   define YYCHAR_NAME yyla.kind()
+#   define YYLA_EMPTY yyla.clear()
 #   define YYLVAL yyla.value
-#   define YYCHAR_NAME yyla.type
+#   define YYLA_CHARNAME_LEX yyla.kind_ = yytranslate_(yylex(&YYLVAL,context))
 #else
-#   define  YYCHAR_NAME yychar
-#   define YYLVAL yylval
+#  define YYEMPTY              (-2)
+#  ifdef NWN_BISON_3
+#      define YYLVAL yyla.value
+#      define YYCHAR_NAME yyla.type
+#  else
+#      define YYCHAR_NAME yychar
+#      define YYLVAL yylval
+#  endif
+#  define YYLA_EMPTY  YYCHAR_NAME = YYEMPTY
+#  define YYLA_CHARNAME_LEX YYCHAR_NAME = yylex(&YYLVAL, context)
 #endif
 
 

--- a/_NscLib/NscCompiler.cpp
+++ b/_NscLib/NscCompiler.cpp
@@ -532,7 +532,7 @@ const char *NscGetActionName (int nAction, NscCompiler *pCompiler)
 //	g_pCtx->yyerror(s);
 //}
 //#else
-#ifdef NWN_BISON_3
+#if (NWN_BISON_3 || NWN_BISON_3_6)
 void yy::parser::error (const std::string& m)
 #else
 void yy::parser::error (const location_type& loc, const std::string& m)

--- a/_NscLib/NscParser.ypp
+++ b/_NscLib/NscParser.ypp
@@ -665,11 +665,11 @@ expression_statement:
 			{
 				if (YYLVAL != NULL)
 					YYLVAL;
-				YYCHAR_NAME = YYEMPTY;
-				YYCHAR_NAME = yylex (&YYLVAL, context);
+				YYLA_EMPTY;
+				YYLA_CHARNAME_LEX;
 			}
 			if (YYCHAR_NAME == ';')
-				YYCHAR_NAME = YYEMPTY;
+				YYLA_EMPTY;
 		}
 	;
 
@@ -992,10 +992,10 @@ translation_unit:
 			{
 				if (YYLVAL != NULL)
 					YYLVAL;
-				YYCHAR_NAME = YYEMPTY;
-				YYCHAR_NAME = yylex (&YYLVAL, context);
+				YYLA_EMPTY;
+				YYLA_CHARNAME_LEX;
 			}
-			YYCHAR_NAME = YYEMPTY;
+			YYLA_EMPTY;
 		} 	
 	;
 


### PR DESCRIPTION
Use macro games to work with newer bison, greater than
3.6.0. Tested with 3.6.4 and 3.0.4.

I use my own tree based on the same original nwnnsscomp code. I hit the issue with the newer bison changes as well. That part of the code is still pretty much the same as yours so I thought I'd offer up what I did in case you want it.  I've done a fair bit of testing of the results with my nwnnsscomp.  I don't have a pre-bison3  system so that is untested. 

Reworked the macros a bit to make the code cleaner.  

Use it if you want or rewrite it or ignore it :)