### PR TITLE
Allow includes compilation & skipping outfile generation

### DIFF
--- a/_NscLib/NscCodeGenerator.cpp
+++ b/_NscLib/NscCodeGenerator.cpp
@@ -134,12 +134,14 @@ CNscCodeGenerator::~CNscCodeGenerator ()
 // @parm CNwnStream * | pDebugOutput | Destination stream for NDB file. 
 //		(Can be NULL)
 //
+// @parm bool | IgnoreIncludes | Either or not we compile includes. 
+//
 // @rdesc TRUE if output was generated.
 //
 //-----------------------------------------------------------------------------
 
 bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput, 
-	CNwnStream *pDebugOutput)
+	CNwnStream *pDebugOutput, bool IgnoreIncludes)
 {
 
 	//
@@ -192,11 +194,15 @@ bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput,
 				return false;
 			}
 		}
-		else
-		{
-			m_pCtx ->GenerateMessage (NscMessage_ErrorEntrySymbolNotFound);
-			return false;
-		}
+	}
+
+	if (IgnoreIncludes && pSymbol == NULL)	{
+		m_pCtx ->GenerateMessage (NscMessage_ErrorEntrySymbolNotFound);
+		return false;
+	// If we want to compile an include, treat it like a StartingConditional
+	} else if (!IgnoreIncludes && pSymbol == NULL) {
+		pszRoutine = "StartingConditional";
+		fIsMain = false;
 	}
 
 	//

--- a/_NscLib/NscCodeGenerator.h
+++ b/_NscLib/NscCodeGenerator.h
@@ -98,7 +98,7 @@ public:
 
 	// @cmember Generate the output
 
-	bool GenerateOutput (CNwnStream *pCodeOutput, CNwnStream *pDebugOutput);
+	bool GenerateOutput (CNwnStream *pCodeOutput, CNwnStream *pDebugOutpu, bool IgnoreIncludes);
 
 // @access Public inline methods
 public:

--- a/_NscLib/NscCompiler.cpp
+++ b/_NscLib/NscCompiler.cpp
@@ -410,7 +410,7 @@ NscResult NscCompileScript (CNwnLoader *pLoader, const char *pszName,
 
 	try
 	{
-		if (!sGen .GenerateOutput (pCodeOutput, pDebugOutput))
+		if (!sGen .GenerateOutput (pCodeOutput, pDebugOutput, fIgnoreIncludes))
 			return NscResult_Failure;
 	}
 	catch (std::exception)

--- a/nwnsc/nwnsc.cpp
+++ b/nwnsc/nwnsc.cpp
@@ -966,7 +966,7 @@ Environment:
             return false;
 
         case NscResult_Include:
-            if (!Quiet) {
+            if (!Quiet && IgnoreIncludes) {
                 TextOut->WriteText(
                         "%s.nss is an include file, ignored.",
                         InFile.RefStr);
@@ -990,8 +990,14 @@ Environment:
     //
 
     FileName = OutBaseFile;
-    FileName += ".ncs";
 
+    if (FileName == "SKIP_OUTPUT") {
+        TextOut->WriteText(
+                "Skipped compiled file generation.\n");
+        return true;
+    }
+
+    FileName += ".ncs";
     f = fopen(FileName.c_str(), "wb");
 
     if (f == nullptr) {
@@ -1768,6 +1774,7 @@ Environment:
     StringVec ResponseFileText;
     StringArgVec ResponseFileArgs;
     bool Compile = true;
+    bool IgnoreIncludes = true;
     bool Optimize = false;
     bool EnableExtensions = false;
     bool NoDebug = true;
@@ -1998,6 +2005,10 @@ Environment:
                             Optimize = true;
                             break;
 
+                        case 'c':
+                            IgnoreIncludes = false;
+                            break;
+
                         case 'p':
                             CompilerFlags |= NscCompilerFlag_DumpPCode;
                             break;
@@ -2133,6 +2144,7 @@ Environment:
                         "  -m mode        - Compiler mode 1.69 or 1.74 - (default 1.74) \n"
                         "  -x errprefix   - Prefix string to prepend to compiler errors (default \"Error\")\n\n"
                         "  -d - Disassemble the script (overrides default compile\n"
+                        "  -c - Compile includes\n"
                         "  -e - Enable non-BioWare extensions\n"
                         "  -g - Enable generation of .ndb debug symbols file\n"
                         "  -j - Show where include file are being sourced from\n"
@@ -2287,7 +2299,7 @@ Environment:
                     Compile,
                     CompilerVersion,
                     Optimize,
-                    true,
+                    IgnoreIncludes,
                     NoDebug,
                     Quiet,
                     VerifyCode,
@@ -2350,7 +2362,7 @@ Environment:
                     Compile,
                     CompilerVersion,
                     Optimize,
-                    true,
+                    IgnoreIncludes,
                     NoDebug,
                     Quiet,
                     VerifyCode,


### PR DESCRIPTION
Hi!

This PR adds a new parameter to the compiler; the `-c` parameter can now be passed to compile includes.  Why is that useful? It is strictly from a development point of view really, it will allow a user to troubleshoot an include file directly instead of having to compile a `main` or `StartingConditional` file including the include itself. It is also important to note that an include compilation run will never generate any output file.

This PR also adds a way to skip the compiled file generation by providing `SKIP_OUTPUT` to the `r` parameter. It was already possible by specifying a non-exisiting file with the `-r` parameter, now however the compiler will just skip the step right away instead of failing.

EDIT:
It probably worth adding this new version of the compiler has been tested on Windows and Linux (WSL2) and was working fine.

Thank you!
