### PR TITLE
fix nullpointer issue for non-ignored includes

### DIFF
--- a/_NscLib/NscCodeGenerator.cpp
+++ b/_NscLib/NscCodeGenerator.cpp
@@ -256,10 +256,12 @@ bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput,
 	// Add our main
 	//
 
-	pSymbol ->ulFlags |= NscSymFlag_Referenced;
-	m_anFunctions .push_back (m_pCtx ->GetSymbolOffset (pSymbol));
-	GatherUsed (pSymbol);
-	
+	if (pSymbol)
+	{
+		pSymbol->ulFlags |= NscSymFlag_Referenced;
+		m_anFunctions.push_back(m_pCtx->GetSymbolOffset(pSymbol));
+		GatherUsed(pSymbol);
+	}
 	//
 	// Initialize the stack depths
 	//

--- a/_NscLib/NscCodeGenerator.cpp
+++ b/_NscLib/NscCodeGenerator.cpp
@@ -262,6 +262,7 @@ bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput,
 		m_anFunctions.push_back(m_pCtx->GetSymbolOffset(pSymbol));
 		GatherUsed(pSymbol);
 	}
+
 	//
 	// Initialize the stack depths
 	//
@@ -600,8 +601,12 @@ bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput,
 		return false;
 	
 	//
-	// Write the output
+	// Write the output.
+	// Return early if file is not executable.
 	//
+
+	if (pSymbol == NULL)
+		return true;
 
 	UINT32 ulSize = (UINT32) (m_pauchOut - m_pauchCode);
 	WriteINT32 (&m_pauchCode [9], ulSize);

--- a/_NscLib/NscCompiler.cpp
+++ b/_NscLib/NscCompiler.cpp
@@ -419,8 +419,25 @@ NscResult NscCompileScript (CNwnLoader *pLoader, const char *pszName,
 
 	try
 	{
-		if (!sGen .GenerateOutput (pCodeOutput, pDebugOutput, fIgnoreIncludes))
+		if (sGen .GenerateOutput (pCodeOutput, pDebugOutput, fIgnoreIncludes))
+		{
+			//
+			// If using the -c flag, prevent creating a compiled file.
+			//
+
+			if (!fIgnoreIncludes && !sCtx .HasMain ())
+			{
+				if (fAllocated)
+					free (pauchData);
+				return NscResult_Include;
+			}
+		}
+		else
 			return NscResult_Failure;
+
+
+		//if (!sGen .GenerateOutput (pCodeOutput, pDebugOutput, fIgnoreIncludes))
+		//	return NscResult_Failure;
 	}
 	catch (std::exception)
 	{


### PR DESCRIPTION
When the `-c` option was activated, the `StartingConditional` `pSymbol` was simulated, but was never checked for `NULL` in subsequent calls that required a valid `pSymbol` value.  This change wraps the few lines that require a valid `pSymbol` in a an `if` scope.  Basic testing showed that it worked correrctly, allowing compilation to continue for executable files, while still finding errors directly in `include` files.