### PR TITLE
Add missing stdlib includes for Linux

### DIFF
--- a/_NwnUtilLib/BufferParser.h
+++ b/_NwnUtilLib/BufferParser.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <cstddef>
+#include <stdint.h>
 #endif
 
 namespace swutil


### PR DESCRIPTION
Currently, building on Linux using GCC 13.1.1 fails. This adds a missing include which allows it to compile again.